### PR TITLE
Toggle MCP content in the system prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,16 @@
 	"activationEvents": [],
 	"main": "./dist/extension.js",
 	"contributes": {
+		"configuration": {
+			"title": "Cline",
+			"properties": {
+				"cline.mcp.includeInPrompt": {
+					"type": "boolean",
+					"default": true,
+					"description": "Include MCP server functionality in AI prompts. When disabled, the AI will not be aware of MCP capabilities. This saves context window tokens."
+				}
+			}
+		},
 		"viewsContainers": {
 			"activitybar": [
 				{

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -1192,6 +1192,14 @@ export class Cline {
 			mcpHub,
 			this.browserSettings,
 		)
+		this.providerRef
+			.deref()
+			?.log(
+				`System prompt length with MCP ${mcpHub.shouldIncludeInPrompt() ? "enabled" : "disabled"}: ${systemPrompt.length} characters`,
+			)
+		// console.error(
+		// 	`System prompt length with MCP ${mcpHub.shouldIncludeInPrompt() ? "enabled" : "disabled"}: ${systemPrompt.length} characters`,
+		// )
 		let settingsCustomInstructions = this.customInstructions?.trim()
 		const clineRulesFilePath = path.resolve(cwd, GlobalFileNames.clineRules)
 		let clineRulesFileInstructions: string | undefined

--- a/src/core/prompts/system.ts
+++ b/src/core/prompts/system.ts
@@ -177,6 +177,9 @@ Usage:
 		: ""
 }
 
+${
+	mcpHub.shouldIncludeInPrompt()
+		? `
 ## use_mcp_tool
 Description: Request to use a tool provided by a connected MCP server. Each MCP server can provide multiple tools with different capabilities. Tools have defined input schemas that specify required and optional parameters.
 Parameters:
@@ -205,6 +208,9 @@ Usage:
 <server_name>server name here</server_name>
 <uri>resource URI here</uri>
 </access_mcp_resource>
+`
+		: ""
+}
 
 ## ask_followup_question
 Description: Ask the user a question to gather additional information needed to complete the task. This tool should be used when you encounter ambiguities, need clarification, or require more details to proceed effectively. It allows for interactive problem-solving by enabling direct communication with the user. Use this tool judiciously to maintain a balance between gathering necessary information and avoiding excessive back-and-forth.
@@ -238,27 +244,7 @@ Your final result description here
 <requires_approval>false</requires_approval>
 </execute_command>
 
-## Example 2: Requesting to use an MCP tool
-
-<use_mcp_tool>
-<server_name>weather-server</server_name>
-<tool_name>get_forecast</tool_name>
-<arguments>
-{
-  "city": "San Francisco",
-  "days": 5
-}
-</arguments>
-</use_mcp_tool>
-
-## Example 3: Requesting to access an MCP resource
-
-<access_mcp_resource>
-<server_name>weather-server</server_name>
-<uri>weather://san-francisco/current</uri>
-</access_mcp_resource>
-
-## Example 4: Requesting to create a new file
+## Example 2: Requesting to create a new file
 
 <write_to_file>
 <path>src/frontend-config.json</path>
@@ -280,7 +266,7 @@ Your final result description here
 </content>
 </write_to_file>
 
-## Example 6: Requesting to make targeted edits to a file
+## Example 3: Requesting to make targeted edits to a file
 
 <replace_in_file>
 <path>src/components/App.tsx</path>
@@ -314,6 +300,31 @@ return (
 >>>>>>> REPLACE
 </diff>
 </replace_in_file>
+${
+	mcpHub.shouldIncludeInPrompt()
+		? `
+
+## Example 4: Requesting to use an MCP tool
+
+<use_mcp_tool>
+<server_name>weather-server</server_name>
+<tool_name>get_forecast</tool_name>
+<arguments>
+{
+  "city": "San Francisco",
+  "days": 5
+}
+</arguments>
+</use_mcp_tool>
+
+## Example 5: Requesting to access an MCP resource
+
+<access_mcp_resource>
+<server_name>weather-server</server_name>
+<uri>weather://san-francisco/current</uri>
+</access_mcp_resource>`
+		: ""
+}
 
 # Tool Use Guidelines
 
@@ -336,6 +347,9 @@ It is crucial to proceed step-by-step, waiting for the user's message after each
 
 By waiting for and carefully considering the user's response after each tool use, you can react accordingly and make informed decisions about how to proceed with the task. This iterative process helps ensure the overall success and accuracy of your work.
 
+${
+	mcpHub.shouldIncludeInPrompt()
+		? `
 ====
 
 MCP SERVERS
@@ -727,11 +741,11 @@ npm run build
 ## Editing MCP Servers
 
 The user may ask to add tools or resources that may make sense to add to an existing MCP server (listed under 'Connected MCP Servers' above: ${
-	mcpHub
-		.getServers()
-		.map((server) => server.name)
-		.join(", ") || "(None running currently)"
-}, e.g. if it would use the same API. This would be possible if you can locate the MCP server repository on the user's system by looking at the server arguments for a filepath. You might then use list_files and read_file to explore the files in the repository, and use replace_in_file to make changes to the files.
+				mcpHub
+					.getServers()
+					.map((server) => server.name)
+					.join(", ") || "(None running currently)"
+			}, e.g. if it would use the same API. This would be possible if you can locate the MCP server repository on the user's system by looking at the server arguments for a filepath. You might then use list_files and read_file to explore the files in the repository, and use replace_in_file to make changes to the files.
 
 However some MCP servers may be running from installed packages rather than a local repository, in which case it may make more sense to create a new MCP server.
 
@@ -740,7 +754,9 @@ However some MCP servers may be running from installed packages rather than a lo
 The user may not always request the use or creation of MCP servers. Instead, they might provide tasks that can be completed with existing tools. While using the MCP SDK to extend your capabilities can be useful, it's important to understand that this is just one specialized type of task you can accomplish. You should only implement MCP servers when the user explicitly requests it (e.g., "add a tool that...").
 
 Remember: The MCP documentation and example provided above are to help you understand and work with existing MCP servers or create new ones when requested by the user. You already have access to tools and capabilities that can be used to accomplish a wide range of tasks.
-
+`
+		: ""
+}
 ====
 
 EDITING FILES
@@ -832,7 +848,13 @@ CAPABILITIES
 		? "\n- You can use the browser_action tool to interact with websites (including html files and locally running development servers) through a Puppeteer-controlled browser when you feel it is necessary in accomplishing the user's task. This tool is particularly useful for web development tasks as it allows you to launch a browser, navigate to pages, interact with elements through clicks and keyboard input, and capture the results through screenshots and console logs. This tool may be useful at key stages of web development tasks-such as after implementing new features, making substantial changes, when troubleshooting issues, or to verify the result of your work. You can analyze the provided screenshots to ensure correct rendering or identify errors, and review console logs for runtime issues.\n	- For example, if asked to add a component to a react website, you might create the necessary files, use execute_command to run the site locally, then use browser_action to launch the browser, navigate to the local server, and verify the component renders & functions correctly before closing the browser."
 		: ""
 }
+${
+	mcpHub.shouldIncludeInPrompt()
+		? `
 - You have access to MCP servers that may provide additional tools and resources. Each server may provide different capabilities that you can use to accomplish tasks more effectively.
+`
+		: ""
+}
 
 ====
 
@@ -861,12 +883,18 @@ RULES
 - When presented with images, utilize your vision capabilities to thoroughly examine them and extract meaningful information. Incorporate these insights into your thought process as you accomplish the user's task.
 - At the end of each user message, you will automatically receive environment_details. This information is not written by the user themselves, but is auto-generated to provide potentially relevant context about the project structure and environment. While this information can be valuable for understanding the project context, do not treat it as a direct part of the user's request or response. Use it to inform your actions and decisions, but don't assume the user is explicitly asking about or referring to this information unless they clearly do so in their message. When using environment_details, explain your actions clearly to ensure the user understands, as they may not be aware of these details.
 - Before executing commands, check the "Actively Running Terminals" section in environment_details. If present, consider how these active processes might impact your task. For example, if a local development server is already running, you wouldn't need to start it again. If no active terminals are listed, proceed with command execution as normal.
-- MCP operations should be used one at a time, similar to other tool usage. Wait for confirmation of success before proceeding with additional operations.
 - When using the replace_in_file tool, you must include complete lines in your SEARCH blocks, not partial lines. The system requires exact line matches and cannot match partial lines. For example, if you want to match a line containing "const x = 5;", your SEARCH block must include the entire line, not just "x = 5" or other fragments.
 - When using the replace_in_file tool, if you use multiple SEARCH/REPLACE blocks, list them in the order they appear in the file. For example if you need to make changes to both line 10 and line 50, first include the SEARCH/REPLACE block for line 10, followed by the SEARCH/REPLACE block for line 50.
 - It is critical you wait for the user's response after each tool use, in order to confirm the success of the tool use. For example, if asked to make a todo app, you would create a file, wait for the user's response it was created successfully, then create another file if needed, wait for the user's response it was created successfully, etc.${
 	supportsComputerUse
 		? " Then if you want to test your work, you might use browser_action to launch the site, wait for the user's response confirming the site was launched along with a screenshot, then perhaps e.g., click a button to test functionality if needed, wait for the user's response confirming the button was clicked along with a screenshot of the new state, before finally closing the browser."
+		: ""
+}
+${
+	mcpHub.shouldIncludeInPrompt()
+		? `
+- MCP operations should be used one at a time, similar to other tool usage. Wait for confirmation of success before proceeding with additional operations.
+`
 		: ""
 }
 

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -84,6 +84,10 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 	mcpHub?: McpHub
 	private latestAnnouncementId = "jan-6-2025" // update to some unique identifier when we add a new announcement
 
+	public log(message: string) {
+		this.outputChannel.appendLine(message)
+	}
+
 	constructor(
 		readonly context: vscode.ExtensionContext,
 		private readonly outputChannel: vscode.OutputChannel,

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -54,6 +54,10 @@ export class McpHub {
 		return this.connections.map((conn) => conn.server)
 	}
 
+	shouldIncludeInPrompt(): boolean {
+		return vscode.workspace.getConfiguration("cline.mcp").get("includeInPrompt") ?? true
+	}
+
 	async getMcpServersPath(): Promise<string> {
 		const provider = this.providerRef.deref()
 		if (!provider) {


### PR DESCRIPTION
### Description

This PR implements MCP prompt control functionality, allowing users to conditionally include/exclude MCP-related content from system prompts via VSCode settings. This feature helps reduce context window token usage when MCP functionality is not needed.

Key changes:

-   Added VSCode setting `cline.mcp.includeInPrompt` to control MCP content visibility
-   Added `shouldIncludeInPrompt()` method to McpHub to read the setting
-   Updated system prompt generation to conditionally include MCP sections
    When MCP content is excluded:
-   MCP tools and examples won't appear in the system prompt
-   The model won't attempt to use MCP functionality
-   Context window tokens are saved
-   No changes to actual MCP functionality (only affects prompt content)

### Type of Change

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

Settings UI:
<img width="1348" alt="Screenshot 2025-01-19 at 5 59 00 PM" src="https://github.com/user-attachments/assets/946ff59e-c0cb-4cce-aca6-1c35582828cd" />


### Additional Notes

The implementation maintains proper markdown formatting and example numbering consistency whether MCP is enabled or disabled. The capabilities section reads naturally in both states.

To toggle MCP content in prompts:

1. Open VSCode Settings (Cmd/Ctrl + ,)
2. Search for "Cline MCP"
3. Toggle "Include In Prompt" setting

### System Prompt Length Analysis

To measure the impact on token usage, we temporarily added logging in `src/core/Cline.ts` to track system prompt length:

```typescript
// In recursivelyMakeClineRequests method
let systemPrompt = await SYSTEM_PROMPT(cwd, this.api.getModel().info.supportsComputerUse ?? false, mcpHub, this.browserSettings)
this.providerRef
	.deref()
	?.log(
		`System prompt length with MCP ${mcpHub.shouldIncludeInPrompt() ? "enabled" : "disabled"}: ${systemPrompt.length} characters`,
	)
```

Results:

-   With MCP enabled: [53856] characters
-   With MCP disabled: [36514] characters

### Behavior Notes

The MCP setting affects how the system prompt is passed to each API request. While different APIs handle system prompts differently (e.g., as a separate parameter, first message in history, or model instruction), the behavior remains consistent:

1. For each API request:
   - A new system prompt is generated using the current MCP setting
   - The system prompt is passed to the API according to its specific requirements
   - The conversation history is maintained separately

2. When toggling MCP mid-conversation:
   - The next request will use a new system prompt (with or without MCP content)
   - Previous messages remain in the conversation history, including any references to MCP tools/capabilities
   - This means the model might see messages referencing capabilities that are no longer available in its current system prompt

3. This implementation means:
   - Each request accurately reflects current MCP settings
   - The model maintains conversation context
   - But must handle potential mismatches between current capabilities and previous MCP interactions

For the best experience, users should:

-   Prefer starting new conversations when changing the MCP setting
-   Be aware that toggling mid-conversation may lead to inconsistent behavior if previous messages referenced MCP functionality

